### PR TITLE
feat: Implement Home page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:sagi_jeonae_app/src/widgets/search_textfield_button.dart';
 
 void main() {
   runApp(const MyApp());
@@ -34,50 +35,54 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('사기 전에'),
-      ),
-      body: Center(
-        child: Column(
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          bottom: const TabBar(
+            tabs: [
+              Tab(icon: Icon(Icons.link), text: 'url'),
+              Tab(icon: Icon(Icons.shopping_bag), text: '상품'),
+              Tab(icon: Icon(Icons.factory), text: '제조사/수입사'),
+            ],
+          ),
+          title: const Text('사기 전에'),
+        ),
+        body: TabBarView(
             children: [
-              Padding(
-                padding: const EdgeInsets.all(20.0),
-                child: TextField(
-                  controller: _inputController,
-                  decoration: const InputDecoration(
-                    labelText: '🔍',
-                  ),
-                ),
-              ),
-              ElevatedButton(
-                child: const Text('검색 하기'),
-                onPressed: () {
-                  String userInput = _inputController.text.trim();
-                  if (userInput.isEmpty) {
-                    final snackBar = SnackBar(
-                      content: const Text('검색어를 입력해 주세요'),
-                      action: SnackBarAction(
-                        label: 'Undo',
-                        onPressed: () {},
-                      ),
-                    );
-
-                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
-                  } else {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (context) =>
-                              ProductInfoPage(data: userInput)),
-                    );
-                  }
-                },
-              ),
+              SearchTextFieldButton(
+                  controller: _inputController, onSearch: _handleSearch),
+              SearchTextFieldButton(
+                  controller: _inputController, onSearch: _handleSearch),
+              SearchTextFieldButton(
+                  controller: _inputController, onSearch: _handleSearch),
             ]
         ),
       ),
     );
+  }
+
+  void _handleSearch() {
+    String userInput = _inputController.text.trim();
+
+    if (userInput.isEmpty) {
+      final snackBar = SnackBar(
+        content: const Text('검색어를 입력해 주세요'),
+        action: SnackBarAction(
+          label: 'Undo',
+          onPressed: () {},
+        ),
+      );
+
+      ScaffoldMessenger.of(context).showSnackBar(snackBar);
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ProductInfoPage(data: userInput),
+        ),
+      );
+    }
   }
 }
 
@@ -94,17 +99,17 @@ class ProductInfoPage extends StatelessWidget {
         title: const Text('검색 결과'),
       ),
       body: Center(
-        child: Column(
-          children: [
-            Text(data ?? 'no data'),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              child: const Text('홈으로!'),
-            ),
-          ],
-        )
+          child: Column(
+            children: [
+              Text(data ?? 'no data'),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: const Text('홈으로!'),
+              ),
+            ],
+          )
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,8 +42,8 @@ class _MyHomePageState extends State<MyHomePage> {
           bottom: const TabBar(
             tabs: [
               Tab(icon: Icon(Icons.link), text: 'url'),
-              Tab(icon: Icon(Icons.shopping_bag), text: '상품'),
-              Tab(icon: Icon(Icons.factory), text: '제조사/수입사'),
+              Tab(icon: Icon(Icons.shopping_bag), text: '제품명'),
+              Tab(icon: Icon(Icons.factory), text: '제조사/수입사명'),
             ],
           ),
           title: const Text('사기 전에'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,23 +11,8 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Sagi Jeonae',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a blue toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
@@ -39,87 +24,88 @@ class MyApp extends StatelessWidget {
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
 
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
   final String title;
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
-
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+  final TextEditingController _inputController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: const Text('사기 전에'),
       ),
       body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
         child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: TextField(
+                  controller: _inputController,
+                  decoration: const InputDecoration(
+                    labelText: '🔍',
+                  ),
+                ),
+              ),
+              ElevatedButton(
+                child: const Text('검색 하기'),
+                onPressed: () {
+                  String userInput = _inputController.text.trim();
+                  if (userInput.isEmpty) {
+                    final snackBar = SnackBar(
+                      content: const Text('검색어를 입력해 주세요'),
+                      action: SnackBarAction(
+                        label: 'Undo',
+                        onPressed: () {},
+                      ),
+                    );
+
+                    ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                  } else {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) =>
+                              ProductInfoPage(data: userInput)),
+                    );
+                  }
+                },
+              ),
+            ]
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+
+class ProductInfoPage extends StatelessWidget {
+  final String data;
+
+  const ProductInfoPage({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('검색 결과'),
+      ),
+      body: Center(
+        child: Column(
+          children: [
+            Text(data ?? 'no data'),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text('홈으로!'),
+            ),
+          ],
+        )
+      ),
     );
   }
 }

--- a/lib/src/widgets/search_textfield_button.dart
+++ b/lib/src/widgets/search_textfield_button.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class SearchTextFieldButton extends StatelessWidget {
+  const SearchTextFieldButton({
+    super.key,
+    required this.controller,
+    required this.onSearch,
+  });
+
+  final TextEditingController controller;
+  final VoidCallback onSearch;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+        children: [
+          Row(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TextField(
+                      controller: controller,
+                      decoration: const InputDecoration(
+                        labelText: '검색어를 입력하세요',
+                      ),
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: onSearch,
+                  child: const Text('검색'),
+                )
+              ]
+          ),
+        ],
+    );
+  }
+}


### PR DESCRIPTION
close #5

### 작업 내용
- [`TabBar`, `TabView` 를 사용](https://docs.flutter.dev/cookbook/design/tabs#interactive-example)하여 url, 제품명, 제조사/수입사명 분리
    - <img width="300" alt="image" src="https://github.com/chaejin-jen/sagi-jeonae-flutter-app/assets/73324850/fb42bc0f-2ab8-46fe-bd82-588b35dc3573">
    - [이유 1] 재사용성 - 통일된 뷰와 같은 사용자 입력 값 사용
    - [이유 2] 확장성 - 버튼 `onPressed`시 서로 다른 로직 실행
    - [이유 3] 가독성 - 어떤 서비스가 호출되는지 `HomePage` 클래스에서 확인 가능  
    
- `TextField` 와 `state` 사용
    - 사용자 입력 값 업데이트 및 유지
- 사용자 입력값 예외시 [`SnackBar`](https://docs.flutter.dev/cookbook/design/snackbars) 로 처리
    - <img width="200" alt="image" src="https://github.com/chaejin-jen/sagi-jeonae-flutter-app/assets/73324850/c27ee14a-43a6-413a-a683-ea6338b1963e">

- 검색 [버튼 누르면 결과 페이지로 넘어가기](https://docs.flutter.dev/cookbook/navigation/navigation-basics#interactive-example) `Navigator.push` 사용
    - <img width="300" alt="image" src="https://github.com/chaejin-jen/sagi-jeonae-flutter-app/assets/73324850/bbef987d-a44c-4279-8f50-f90aa1da7b30">


### Discussion
- 페이지 구성 계획 변경
    - 계획: screens/home, screens/product_info 에 각 페이지를 구현
        - flutter cookbook 에서 영감을 받음
    - 실제: main.dart 에서 두 개의 페이지 클래스 정의
    - 느낀 점: 프로젝트 규모에 따라 구조 짜기.. 와이어 프레임 왜 그렸징.. 프레임워크에 대한 지식과 친숙함이 있으면 아이디어가 바로 나오구나..
- ui 로직과 비즈니스 로직의 분리
    - ui 로직 예시 : 사용자 입력값으로 검색시, 빈 값일 때 예외처리나, 서비스 호출 후 결과 페이지로 넘어가는 것
    - 일단은 HomePage 클래스에 뒀는데, 코드가 길고 복잡해지면 어디다 빼면 좋을까..?
