### PR TITLE
refactor : Introduce Handler and apply to handleSearch in main

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -201,7 +201,8 @@ List<String> generateCustomTitle(List<Map<String, dynamic>?>? data) {
       String manufacturer = item["제조수입업체명"] != null
           ? '${item["제조수입업체명"]}\n'
           : '';
-      String product = item["제품명"] ?? item["모델명"] ?? item["품목명"] ?? '';
+      String product = item["제품명"] ?? item["모델명"] ?? item["품목명"] ??
+          item["업소명"] ?? '';
       if (manufacturer.isEmpty && product.isEmpty) return '제품공시정보';
       return '$manufacturer$product';
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:sagi_jeonae_app/src/services/search_service.dart';
+import 'package:sagi_jeonae_app/src/data/enums/search_type.dart';
+import 'package:sagi_jeonae_app/src/services/search_service_handler.dart';
 import 'package:sagi_jeonae_app/src/services/udipotal_mfds_service.dart';
 import 'package:sagi_jeonae_app/src/widgets/search_textfield_button.dart';
 import 'package:sagi_jeonae_app/src/widgets/search_result_table.dart';
@@ -40,8 +41,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    final searchService = SearchService();
-
     return DefaultTabController(
       length: 3,
       child: Scaffold(
@@ -59,17 +58,17 @@ class _MyHomePageState extends State<MyHomePage> {
             children: [
               SearchTextFieldButton(
                   controller: _inputController,
-                  onSearch: () => _handleSearch(searchService.searchByUrl)
+                  onSearch: () => _handleSearch(SearchType.url)
               ),
               SearchTextFieldButton(
                   controller: _inputController,
                   onSearch: () =>
-                      _handleSearch(searchService.searchByProductName)
+                      _handleSearch(SearchType.product)
               ),
               SearchTextFieldButton(
                   controller: _inputController,
                   onSearch: () =>
-                      _handleSearch(searchService.searchByCompanyName)
+                      _handleSearch(SearchType.company)
               ),
             ]
         ),
@@ -77,8 +76,7 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  void _handleSearch(Future<
-      List<Map<String, dynamic>>?> Function(String) searchFunction) async {
+  void _handleSearch(SearchType searchType) async {
     String userInput = _inputController.text.trim();
     final udipotalService = UdiportalMfdsService();
 
@@ -94,7 +92,8 @@ class _MyHomePageState extends State<MyHomePage> {
       ScaffoldMessenger.of(context).showSnackBar(snackBar);
     } else {
       try {
-        final searchResult = await searchFunction(userInput);
+        final searchResult = await SearchServiceHandler.fetchSearchResults(
+            searchType, userInput);
         final String modelName = searchResult != null
             ? searchResult[0]["품명 및 모델명"] ?? ''
             : '';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sagi_jeonae_app/src/data/enums/search_type.dart';
 import 'package:sagi_jeonae_app/src/services/search_service_handler.dart';
-import 'package:sagi_jeonae_app/src/services/udipotal_mfds_service.dart';
+import 'package:sagi_jeonae_app/src/services/udiportal_mfds_service.dart';
 import 'package:sagi_jeonae_app/src/widgets/search_textfield_button.dart';
 import 'package:sagi_jeonae_app/src/widgets/search_result_table.dart';
 import 'package:sagi_jeonae_app/src/widgets/search_result_web_view.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,6 +110,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   productHtml: htmlData['productHtml'],
                   recallHtml: htmlData['recallHtml'],
                   companyHtml: htmlData['companyHtml'],
+                  showNonMedicalDeviceMessage: searchType == SearchType.url &&
+                      htmlData['productHtml'] == null ? true : false,
                 ),
           ),
         );
@@ -126,6 +128,7 @@ class SearchResultPage extends StatelessWidget {
   final String? productHtml;
   final String? recallHtml;
   final String? companyHtml;
+  final bool showNonMedicalDeviceMessage;
 
   const SearchResultPage({
     super.key,
@@ -134,6 +137,7 @@ class SearchResultPage extends StatelessWidget {
     this.productHtml,
     this.recallHtml,
     this.companyHtml,
+    required this.showNonMedicalDeviceMessage,
   });
 
   @override
@@ -157,7 +161,9 @@ class SearchResultPage extends StatelessWidget {
             Text(
                 '검색어 : $keyword', maxLines: 1,
                 overflow: TextOverflow.ellipsis),
-            Text('검색 결과 ${data?.length ?? 0} 건'),
+            showNonMedicalDeviceMessage ? const Text(
+                "의료기기가 아닙니다.", textScaleFactor: 2) : Text(
+                '검색 결과 ${data?.length ?? 0} 건'),
             if (data != null && data!.isNotEmpty)
               Expanded(
                 child:

--- a/lib/src/data/enums/search_type.dart
+++ b/lib/src/data/enums/search_type.dart
@@ -1,0 +1,5 @@
+enum SearchType {
+  url,
+  product,
+  company,
+}

--- a/lib/src/data/model/udiportal_mfds_data_model.dart
+++ b/lib/src/data/model/udiportal_mfds_data_model.dart
@@ -1,7 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:retrofit/http.dart';
 
-part 'udipotal_mfds_data_model.g.dart';
+part 'udiportal_mfds_data_model.g.dart';
 
 @JsonSerializable()
 class MedicalDeviceParams {

--- a/lib/src/data/model/udiportal_mfds_data_model.g.dart
+++ b/lib/src/data/model/udiportal_mfds_data_model.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'udipotal_mfds_data_model.dart';
+part of 'udiportal_mfds_data_model.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator

--- a/lib/src/data/remote/api/udiportal_mfds_api.dart
+++ b/lib/src/data/remote/api/udiportal_mfds_api.dart
@@ -1,9 +1,9 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
-import 'package:sagi_jeonae_app/src/data/model/udipotal_mfds_data_model.dart';
+import 'package:sagi_jeonae_app/src/data/model/udiportal_mfds_data_model.dart';
 
 
-part 'udipotal_mfds_api.g.dart';
+part 'udiportal_mfds_api.g.dart';
 
 @RestApi(baseUrl: "http://udiportal.mfds.go.kr")
 abstract class UdiportalMfdsApi {

--- a/lib/src/data/remote/api/udiportal_mfds_api.g.dart
+++ b/lib/src/data/remote/api/udiportal_mfds_api.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'udipotal_mfds_api.dart';
+part of 'udiportal_mfds_api.dart';
 
 // **************************************************************************
 // RetrofitGenerator

--- a/lib/src/services/search_service_handler.dart
+++ b/lib/src/services/search_service_handler.dart
@@ -1,0 +1,20 @@
+import 'package:sagi_jeonae_app/src/data/enums/search_type.dart';
+import 'package:sagi_jeonae_app/src/services/search_service.dart';
+
+class SearchServiceHandler {
+  static Future<List<Map<String, dynamic>>?> fetchSearchResults(SearchType searchType,
+      String queryParam,) async {
+    final searchService = SearchService();
+
+    switch (searchType) {
+      case SearchType.url:
+        return await searchService.searchByUrl(queryParam);
+      case SearchType.product:
+        return await searchService.searchByProductName(queryParam);
+      case SearchType.company:
+        return await searchService.searchByCompanyName(queryParam);
+      default:
+        throw ArgumentError('Invalid search type');
+    }
+  }
+}

--- a/lib/src/services/udiportal_mfds_service.dart
+++ b/lib/src/services/udiportal_mfds_service.dart
@@ -1,6 +1,6 @@
 import 'package:dio/dio.dart';
-import 'package:sagi_jeonae_app/src/data/model/udipotal_mfds_data_model.dart';
-import 'package:sagi_jeonae_app/src/data/remote/api/udipotal_mfds_api.dart';
+import 'package:sagi_jeonae_app/src/data/model/udiportal_mfds_data_model.dart';
+import 'package:sagi_jeonae_app/src/data/remote/api/udiportal_mfds_api.dart';
 
 class UdiportalMfdsService {
   final UdiportalMfdsApi _udiportApi;

--- a/lib/src/services/udiportal_mfds_service_handler.dart
+++ b/lib/src/services/udiportal_mfds_service_handler.dart
@@ -1,0 +1,32 @@
+import 'package:sagi_jeonae_app/src/services/udiportal_mfds_service.dart';
+
+class UdiportalMfdsServiceHandler {
+  static Future<Map<String, String?>> fetchHtmlData(
+      Map<String, dynamic> searchResult,) async {
+    final udiportalService = UdiportalMfdsService();
+
+    final String modelName = searchResult["품명 및 모델명"]
+        .split('/')
+        .length > 1
+        ? searchResult["품명 및 모델명"].split('/')[1]
+        : searchResult["품명 및 모델명"] ?? '';
+
+    final String companyName = searchResult["제조자(수입자)"] ?? '';
+
+    final productHtml = modelName.isNotEmpty
+        ? await udiportalService.fetchMedicalDeviceDataByModelName(modelName)
+        : null;
+    final recallHtml = modelName.isNotEmpty
+        ? await udiportalService.fetchRecallDataByModelName(modelName)
+        : null;
+    final companyHtml = companyName.isNotEmpty
+        ? await udiportalService.fetchDisciplinaryDataByCompanyName(companyName)
+        : null;
+
+    return {
+      'productHtml': productHtml,
+      'recallHtml': recallHtml,
+      'companyHtml': companyHtml,
+    };
+  }
+}


### PR DESCRIPTION
close #16 

### 작업 내용

- page에서 service 를 바로 호출하지 않고, handler 를 호출해서 처리
    - 목적 : 가독성 높이기, 책임 분리
        - 결과적으로 _handlerSearch 를 통해서만 서비스 로직이 실행됨
    - SearchServiceHandler - main view 에서 카테고리 등의 기능이 추가될 경우 여기서 처리 후 SerchService 사용
    - UdiportalMfdsServiceHandler - searchResult 가 복잡해질 경우 여기서 처리 후 UdiportalMfdsService 사용
- 제조사 검색시 업소명 뜨게 수정
- unipotal -> uniportal 로 오타 수정
- url 검색에서, 의료기기가 아닌 경우 "의료기기가 아닙니다." 텍스트 띄워주도록 변경
    - 현재 프론트에서 하드코딩 해놨는데, 백에서 isMedicalDevice 같은 정보 주도록 수정 필요

### Discussion
- main -> handler -> service -> api 이 구조가 맞나
    - 이렇게 파일만 많아졌다..
    - 개인적인 생각으로 다음처럼 책임을 분리했다 생각했는데 더 좋은 방법이 있을까
        - api 는 API 호출 
        - service 에서는 api의 output 처리 (현재 미구현이지만, error 처리를 여기서 할랬음)
        - handler input data 처리해서 서비스 호출 (뷰와 서비스를 연결)